### PR TITLE
User agent proxying support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
-    "h3": "^1.8.1",
+    "h3": "^1.9.0",
     "jose": "^5.2.0",
     "nitropack": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
-    "@tsndr/cloudflare-worker-jwt": "^2.3.2",
     "h3": "^1.8.1",
+    "jose": "^5.2.0",
     "nitropack": "latest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-proxy",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "prepare": "nitropack prepare",
     "dev": "nitropack dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   h3:
-    specifier: ^1.8.1
-    version: 1.8.1
+    specifier: ^1.9.0
+    version: 1.9.0
   jose:
     specifier: ^5.2.0
     version: 5.2.0
@@ -1402,6 +1402,10 @@ packages:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
     dev: false
 
+  /defu@6.1.3:
+    resolution: {integrity: sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ==}
+    dev: false
+
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     dev: false
@@ -1418,6 +1422,10 @@ packages:
 
   /destr@2.0.1:
     resolution: {integrity: sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==}
+    dev: false
+
+  /destr@2.0.2:
+    resolution: {integrity: sha512-65AlobnZMiCET00KaFFjUefxDX0khFA/E4myqZ7a6Sq1yZtR8+FVIvilVX66vF2uobSumxooYZChiRPCKNqhmg==}
     dev: false
 
   /destroy@1.2.0:
@@ -2180,15 +2188,15 @@ packages:
       duplexer: 0.1.2
     dev: false
 
-  /h3@1.8.1:
-    resolution: {integrity: sha512-m5rFuu+5bpwBBHqqS0zexjK+Q8dhtFRvO9JXQG0RvSPL6QrIT6vv42vuBM22SLOgGMoZYsHk0y7VPidt9s+nkw==}
+  /h3@1.9.0:
+    resolution: {integrity: sha512-+F3ZqrNV/CFXXfZ2lXBINHi+rM4Xw3CDC5z2CDK3NMPocjonKipGLLDSkrqY9DOrioZNPTIdDMWfQKm//3X2DA==}
     dependencies:
       cookie-es: 1.0.0
-      defu: 6.1.2
-      destr: 2.0.1
-      iron-webcrypto: 0.8.2
+      defu: 6.1.3
+      destr: 2.0.2
+      iron-webcrypto: 1.0.0
       radix3: 1.1.0
-      ufo: 1.3.0
+      ufo: 1.3.2
       uncrypto: 0.1.3
       unenv: 1.7.4
     dev: false
@@ -2330,8 +2338,8 @@ packages:
       - supports-color
     dev: false
 
-  /iron-webcrypto@0.8.2:
-    resolution: {integrity: sha512-jGiwmpgTuF19Vt4hn3+AzaVFGpVZt7A1ysd5ivFel2r4aNVFwqaYa6aU6qsF1PM7b+WFivZHz3nipwUOXaOnHg==}
+  /iron-webcrypto@1.0.0:
+    resolution: {integrity: sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==}
     dev: false
 
   /is-array-buffer@3.0.2:
@@ -2615,7 +2623,7 @@ packages:
       consola: 3.2.3
       defu: 6.1.2
       get-port-please: 3.1.1
-      h3: 1.8.1
+      h3: 1.9.0
       http-shutdown: 1.2.2
       jiti: 1.20.0
       mlly: 1.4.2
@@ -2834,7 +2842,7 @@ packages:
       fs-extra: 11.1.1
       globby: 13.2.2
       gzip-size: 7.0.0
-      h3: 1.8.1
+      h3: 1.9.0
       hookable: 5.5.3
       httpxy: 0.1.5
       is-primitive: 3.0.1
@@ -3778,6 +3786,10 @@ packages:
     resolution: {integrity: sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==}
     dev: false
 
+  /ufo@1.3.2:
+    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
+    dev: false
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -3890,7 +3902,7 @@ packages:
       anymatch: 3.1.3
       chokidar: 3.5.3
       destr: 2.0.1
-      h3: 1.8.1
+      h3: 1.9.0
       ioredis: 5.3.2
       listhen: 1.5.1
       lru-cache: 10.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@tsndr/cloudflare-worker-jwt':
-    specifier: ^2.3.2
-    version: 2.3.2
   h3:
     specifier: ^1.8.1
     version: 1.8.1
+  jose:
+    specifier: ^5.2.0
+    version: 5.2.0
   nitropack:
     specifier: latest
     version: 2.6.3
@@ -702,10 +702,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.29.1
-    dev: false
-
-  /@tsndr/cloudflare-worker-jwt@2.3.2:
-    resolution: {integrity: sha512-g1jSm5olPqKh15kadnj0666YPudibHYGyFyM0URLXSeY5MzNIGkfhFedLgKHq8NCDBMzLUMX7Oz8d+jmQXqBuw==}
     dev: false
 
   /@types/estree@1.0.1:
@@ -2535,6 +2531,10 @@ packages:
   /jiti@1.20.0:
     resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
     hasBin: true
+    dev: false
+
+  /jose@5.2.0:
+    resolution: {integrity: sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==}
     dev: false
 
   /js-yaml@4.1.0:

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,7 +2,7 @@ import { getBodyBuffer } from '@/utils/body';
 import {
   getProxyHeaders,
   getAfterResponseHeaders,
-  cleanupHeadersBeforeProxy,
+  getBlacklistedHeaders,
 } from '@/utils/headers';
 import {
   createTokenIfNeeded,
@@ -39,8 +39,8 @@ export default defineEventHandler(async (event) => {
   const token = await createTokenIfNeeded(event);
 
   // proxy
-  cleanupHeadersBeforeProxy(event);
-  await proxyRequest(event, destination, {
+  await specificProxyRequest(event, destination, {
+    blacklistedHeaders: getBlacklistedHeaders(),
     fetchOptions: {
       redirect: 'follow',
       headers: getProxyHeaders(event.headers),

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -11,6 +11,7 @@ const blacklistedHeaders = [
   'x-forwarded-proto',
   'forwarded',
   'x-real-ip',
+  'user-agent',
 ];
 
 function copyHeader(
@@ -26,7 +27,7 @@ function copyHeader(
 export function getProxyHeaders(headers: Headers): Headers {
   const output = new Headers();
 
-  // default user-agent
+  // default user agent
   output.set(
     'User-Agent',
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0',

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -26,19 +26,22 @@ function copyHeader(
 export function getProxyHeaders(headers: Headers): Headers {
   const output = new Headers();
 
-  const headerMap: Record<string, string> = {
-    'X-Cookie': 'Cookie',
-    'X-Referer': 'Referer',
-    'X-Origin': 'Origin',
-  };
-  Object.entries(headerMap).forEach((entry) => {
-    copyHeader(headers, output, entry[0], entry[1]);
-  });
-
+  // default user-agent
   output.set(
     'User-Agent',
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0',
   );
+
+  const headerMap: Record<string, string> = {
+    'X-Cookie': 'Cookie',
+    'X-Referer': 'Referer',
+    'X-Origin': 'Origin',
+    'X-User-Agent': 'User-Agent',
+    'X-X-Real-Ip': 'X-Real-Ip',
+  };
+  Object.entries(headerMap).forEach((entry) => {
+    copyHeader(headers, output, entry[0], entry[1]);
+  });
 
   return output;
 }

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,4 +1,10 @@
-import { H3Event } from 'h3';
+const headerMap: Record<string, string> = {
+  'X-Cookie': 'Cookie',
+  'X-Referer': 'Referer',
+  'X-Origin': 'Origin',
+  'X-User-Agent': 'User-Agent',
+  'X-X-Real-Ip': 'X-Real-Ip',
+};
 
 const blacklistedHeaders = [
   'cf-connecting-ip',
@@ -11,7 +17,7 @@ const blacklistedHeaders = [
   'x-forwarded-proto',
   'forwarded',
   'x-real-ip',
-  'user-agent',
+  ...Object.keys(headerMap),
 ];
 
 function copyHeader(
@@ -33,13 +39,6 @@ export function getProxyHeaders(headers: Headers): Headers {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0',
   );
 
-  const headerMap: Record<string, string> = {
-    'X-Cookie': 'Cookie',
-    'X-Referer': 'Referer',
-    'X-Origin': 'Origin',
-    'X-User-Agent': 'User-Agent',
-    'X-X-Real-Ip': 'X-Real-Ip',
-  };
   Object.entries(headerMap).forEach((entry) => {
     copyHeader(headers, output, entry[0], entry[1]);
   });
@@ -64,14 +63,6 @@ export function getAfterResponseHeaders(
   };
 }
 
-export function removeHeadersFromEvent(event: H3Event, key: string) {
-  const normalizedKey = key.toLowerCase();
-  if (event.node.req.headers[normalizedKey])
-    delete event.node.req.headers[normalizedKey];
-}
-
-export function cleanupHeadersBeforeProxy(event: H3Event) {
-  blacklistedHeaders.forEach((key) => {
-    removeHeadersFromEvent(event, key);
-  });
+export function getBlacklistedHeaders() {
+  return blacklistedHeaders;
 }

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,84 @@
+import {
+  H3Event,
+  Duplex,
+  ProxyOptions,
+  getProxyRequestHeaders,
+  RequestHeaders,
+} from 'h3';
+
+const PayloadMethods = new Set(['PATCH', 'POST', 'PUT', 'DELETE']);
+
+export interface ExtraProxyOptions {
+  blacklistedHeaders?: string[];
+}
+
+function mergeHeaders(
+  defaults: HeadersInit,
+  ...inputs: (HeadersInit | RequestHeaders | undefined)[]
+) {
+  const _inputs = inputs.filter(Boolean) as HeadersInit[];
+  if (_inputs.length === 0) {
+    return defaults;
+  }
+  const merged = new Headers(defaults);
+  for (const input of _inputs) {
+    if (input.entries) {
+      for (const [key, value] of (input.entries as any)()) {
+        if (value !== undefined) {
+          merged.set(key, value);
+        }
+      }
+    } else {
+      for (const [key, value] of Object.entries(input)) {
+        if (value !== undefined) {
+          merged.set(key, value);
+        }
+      }
+    }
+  }
+  return merged;
+}
+
+export async function specificProxyRequest(
+  event: H3Event,
+  target: string,
+  opts: ProxyOptions & ExtraProxyOptions = {},
+) {
+  let body;
+  let duplex: Duplex | undefined;
+  if (PayloadMethods.has(event.method)) {
+    if (opts.streamRequest) {
+      body = getRequestWebStream(event);
+      duplex = 'half';
+    } else {
+      body = await readRawBody(event, false).catch(() => undefined);
+    }
+  }
+
+  const method = opts.fetchOptions?.method || event.method;
+  const oldHeaders = getProxyRequestHeaders(event);
+  opts.blacklistedHeaders?.forEach((header) => {
+    const keys = Object.keys(oldHeaders).filter(
+      (v) => v.toLowerCase() === header.toLowerCase(),
+    );
+    keys.forEach((k) => delete oldHeaders[k]);
+  });
+
+  const fetchHeaders = mergeHeaders(
+    oldHeaders,
+    opts.fetchOptions?.headers,
+    opts.headers,
+  );
+  (fetchHeaders.forEach as any)(console.log);
+
+  return sendProxy(event, target, {
+    ...opts,
+    fetchOptions: {
+      method,
+      body,
+      duplex,
+      ...opts.fetchOptions,
+      headers: fetchHeaders,
+    },
+  });
+}


### PR DESCRIPTION
resolves https://github.com/movie-web/movie-web/issues/587

changes:
 - I've realized a lot of headers weren't proxied correctly. This fixes all previous broken headers
 - Switch out JWT library for one that works on both node and cloudflare
 - Add support for `X-User-Agent` for setting user agent.
 - Add support for `X-X-Real-Ip` for setting `X-Real-Ip`
 - properly blacklist headers, they are now gone for good.

> [!IMPORTANT]
> Turns out cloudflare always adds all the `cf-*` headers. Even on subrequests. It is not possible to remove.
> This means that all proxies hosted on cloudflare workers will always be leaking the fact that its coming from cloudflare.