### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the docs at https://docs.movie-web.app/proxy/introduction
 > [!WARNING]
 > Turnstile integration only works properly with cloudflare workers as platform
 >  
-> Click here for more information of [Turnstile with Workers](https://developers.cloudflare.com/workers/examples/turnstile-html-rewriter/)
+> Click here for more information on [Turnstile with Workers](https://developers.cloudflare.com/workers/examples/turnstile-html-rewriter/)
 
 ### supported platforms:
  - cloudflare workers

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Read the docs at https://docs.movie-web.app/proxy/introduction
 
 > [!WARNING]
 > Turnstile integration only works properly with cloudflare workers as platform
+>  
+> Click here for more information of [Turnstile with Workers](https://developers.cloudflare.com/workers/examples/turnstile-html-rewriter/)
 
 ### supported platforms:
  - cloudflare workers


### PR DESCRIPTION
Documentation linking for how Turnstile integration only works properly with cloudflare workers as platform.
Inject Turnstile implicitly into HTML elements using the HTMLRewriter runtime API.